### PR TITLE
Magic method __toString() must return a string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mrrio/shellwrap",
+    "name": "deminy/shellwrap",
     "type": "library",
     "description": "Use any command-line tool as a PHP function.",
     "keywords": ["command", "shell", "api", "command-line", "exec"],

--- a/src/MrRio/ShellWrap.php
+++ b/src/MrRio/ShellWrap.php
@@ -25,7 +25,7 @@ class ShellWrap
     static public $exceptionOnError = true;
 
 
-    private static $output = array();
+    private static $output = '';
     private static $prepend = array();
     private static $stdin = null;
 

--- a/src/MrRio/ShellWrap.php
+++ b/src/MrRio/ShellWrap.php
@@ -144,7 +144,9 @@ class ShellWrap
 
         if (is_resource($process)) {
 
-            fwrite($pipes[0], self::$stdin);
+            if (isset(self::$stdin)) {
+                fwrite($pipes[0], self::$stdin);
+            }
             fclose($pipes[0]);
 
             $output = '';

--- a/src/MrRio/ShellWrap.php
+++ b/src/MrRio/ShellWrap.php
@@ -134,7 +134,13 @@ class ShellWrap
             2 => array('pipe', 'w') // Stderr
         );
 
-        $process = proc_open($shell, $descriptor_spec, $pipes);
+        // If you use function chdir() to change working directory to a different directory first, following two
+        // statements should still return same directories. However, in Travis CI they return different directories back
+        // (the 2nd one returns the directory where the PHP script was invoked).
+        //     1. getcwd()
+        //     2. (string) ShellWrap::pwd()
+        // Thus we have the 4th parameter (getcwd()) specified explicitly here, also ideally it's unnecessary.
+        $process = proc_open($shell, $descriptor_spec, $pipes, getcwd());
 
         if (is_resource($process)) {
 


### PR DESCRIPTION
In some PHP IDE (e.g., PhpStorm) you may see that method _\MrRio\ShellWrap::__toString()_ is highlighted with notification saying

> ___toString() method must return a string_

This could be triggered with following code piece where no actual shell command invoked:

```php
<?php
require_once __DIR__ . '/vendor/autoload.php';

echo (new MrRio\ShellWrap());
?>
```

Although in reality people may not make method calls like that, it's better to get it fix to make variables consistent. Property _\MrRio\ShellWrap::$output_ should be initialized and used as a string but not an array, as in the fix.