### PR TITLE
specify current working directory explicitly when executing shell commands

### DIFF
--- a/src/MrRio/ShellWrap.php
+++ b/src/MrRio/ShellWrap.php
@@ -134,7 +134,13 @@ class ShellWrap
             2 => array('pipe', 'w') // Stderr
         );
 
-        $process = proc_open($shell, $descriptor_spec, $pipes);
+        // If you use function chdir() to change working directory to a different directory first, following two
+        // statements should still return same directories. However, in Travis CI they return different directories back
+        // (the 2nd one returns the directory where the PHP script was invoked).
+        //     1. getcwd()
+        //     2. (string) ShellWrap::pwd()
+        // Thus we have the 4th parameter (getcwd()) specified explicitly here, also ideally it's unnecessary.
+        $process = proc_open($shell, $descriptor_spec, $pipes, getcwd());
 
         if (is_resource($process)) {
 


### PR DESCRIPTION
If you use function _chdir()_ to change working directory to a different directory first, following two statements should still return same directories. However, in Travis CI they return different directories back (the 2nd one returns the directory where the PHP script was invoked).

1. getcwd()
2. (string) ShellWrap::pwd()

Thus we need to have the 4th parameter (getcwd()) specified explicitly here, also ideally it's unnecessary.
